### PR TITLE
Add introduction to NPM lecture with package installation examples an…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "17-modern-js-modules-tooling",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "17-modern-js-modules-tooling",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "leaflet": "^1.9.4",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "17-modern-js-modules-tooling",
+  "version": "1.0.0",
+  "main": "clean.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Jonas",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "leaflet": "^1.9.4",
+    "lodash-es": "^4.17.21"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -76,7 +76,8 @@ shoppingCart2.addToCart('pizza', 2);
 console.log(shoppingCart2);
 console.log(shoppingCart2.shippingCost);
 */
-
+/*
+// 287. CommonJS Modules
 // Export
 exports.addToCart = function (product, quantity) {
   cart.push({ product, quantity });
@@ -87,3 +88,22 @@ exports.addToCart = function (product, quantity) {
 
 // Import
 const { addToCart } = require('./shoppingCart.js');
+*/
+
+import cloneDeep from './node_modules/lodash-es/cloneDeep.js';
+
+const state = {
+  car: [
+    { product: 'bread', quantity: 5 },
+    { product: 'PIZZA', quantity: 5 },
+  ],
+  user: { loggedIn: true },
+};
+
+const stateClone = Object.assign({}, state);
+const stateDeepClone = cloneDeep(state);
+
+state.user.loggedIn = false;
+console.log(stateClone);
+
+console.log(stateDeepClone);


### PR DESCRIPTION
# Introduction to NPM – Lecture 289

## Description
This PR adds the practice code and examples from the "289. Introduction to NPM" lecture.  
It demonstrates:
- Initializing a project with `npm init`
- Installing packages (`leaflet` and `lodash-es`)
- Managing dependencies via `package.json`
- Using `cloneDeep` from `lodash-es` to perform deep cloning of nested objects
- Understanding why `node_modules` should not be committed and how to reinstall dependencies

## Changes
- Added `package.json` through `npm init`
- Installed `leaflet` and `lodash-es` as dependencies
- Implemented example code showing:
  - Shallow copy using `Object.assign`
  - Deep copy using `cloneDeep` from `lodash-es`

## Example Usage
```js
import cloneDeep from './node_modules/lodash-es/cloneDeep.js';

const state = {
  car: [
    { product: 'bread', quantity: 5 },
    { product: 'PIZZA', quantity: 5 },
  ],
  user: { loggedIn: true },
};

const stateClone = Object.assign({}, state);
const stateDeepClone = cloneDeep(state);

state.user.loggedIn = false;
console.log(stateClone);       // Shallow copy affected
console.log(stateDeepClone);   // Deep copy unaffected
```

# Notes

> Avoid committing the node_modules folder to version control.

To reinstall dependencies, simply run:

```
npm install
```
